### PR TITLE
tox.ini: pass {posargs} to py.test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,14 @@ indexserver=
     pypi = https://pypi.python.org/simple
 
 [testenv]
-commands= py.test pytest_splinter tests --pep8 --junitxml={envlogdir}/junit-{envname}.xml
+commands= py.test pytest_splinter tests --pep8 --junitxml={envlogdir}/junit-{envname}.xml {posargs}
 deps = -r{toxinidir}/requirements-testing.txt
 
 [testenv:py27-coverage]
-commands= py.test tests --cov=pytest_splinter --junitxml={envlogdir}/junit-{envname}.xml
+commands= py.test tests --cov=pytest_splinter --junitxml={envlogdir}/junit-{envname}.xml {posargs}
 
 [testenv:py27-xdist]
-commands= py.test pytest_splinter tests --pep8 --junitxml={envlogdir}/junit-{envname}.xml
+commands= py.test pytest_splinter tests --pep8 --junitxml={envlogdir}/junit-{envname}.xml {posargs}
 deps =
     -r{toxinidir}/requirements-testing.txt
     pytest-xdist


### PR DESCRIPTION
This allows to pass `-s`, `-k` etc easily from tox to py.test for example:

    % tox -e py34 -- -s