### PR TITLE
browser does not seem to be truly session scoped

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- make browser_instance_getter session scoped (sureshvv)
+
+
 1.3.3
 -----
 


### PR DESCRIPTION
Cookies are cleared at some point even if it is the same session scoped browser object. This ensures that we can have a true session_scoped_browser that will hold on to the cookies until end of test.