### PR TITLE
Use splinter_selenium_implicit_wait as Browser.wait_time

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -321,7 +321,8 @@ def browser_instance_getter(
 
         return Browser(
             splinter_webdriver, visit_condition=splinter_browser_load_condition,
-            visit_condition_timeout=splinter_browser_load_timeout, **kwargs
+            visit_condition_timeout=splinter_browser_load_timeout,
+            wait_time=splinter_selenium_implicit_wait, **kwargs
         )
 
     def prepare_browser(request, parent):


### PR DESCRIPTION
Splinter methods that check conditions in Python such as ``is_text_present`` loop checking the condition until the wait_time (default: 2) has passed.