### PR TITLE
Use splinter 0.7.3, remove lazy status_code patch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,16 @@
 Changelog
 =========
 
+NEXT
+----
+
+- depend on splinter 0.7.3, remove the previous status_code monkey patch (pelme)
+
 1.4.6
 -----
 
 - ensure base tempdir exists (bubenkoff)
+
 
 1.4.0
 -----

--- a/README.rst
+++ b/README.rst
@@ -200,13 +200,6 @@ As mentioned above, browser is a fixture made by creating splinter's Browser obj
     Method copying selenium's wait_for_condition, with difference that condition is in python,
     so there you can do whatever you want, and not only execute javascript via browser.evaluate_script.
 
-*  `status_code <http://splinter.cobrateam.info/docs/http-status-code-and-exception.html>`_
-    This functionality is overriden. Splinter implements this using additional request from python side,
-    which is in general performance-wise not a good idea. Also normally when you interact with the browser as a user,
-    you don't need the status code of the page. But for those who still need that for some reason, `status_code` is made
-    lazy - when you access it, it will make an additional request (one-time, further accesses to it will return cached
-    value, until next call to `visit`).
-
 
 Several browsers for your test
 ------------------------------

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -31,7 +31,6 @@ NAME_RE = re.compile(r'[\W]')
 
 def _visit(self, url):
     """Override splinter's visit to avoid unnecessary checks and add wait_until instead."""
-    self.__dict__.pop('status_code', None)
     self.driver.get(url)
     self.wait_for_condition(self.visit_condition, timeout=self.visit_condition_timeout)
 
@@ -49,19 +48,6 @@ def _wait_for_condition(self, condition=None, timeout=None, poll_frequency=0.5, 
     )
 
 
-def _get_status_code(self):
-    """Lazy status code get."""
-    inst_status_code = self.__dict__.get('status_code')
-    if inst_status_code:
-        return inst_status_code
-    self.connect(self.url)
-    return self.status_code
-
-
-def _set_status_code(self, value):
-    """Lazy status code set."""
-    self.__dict__['status_code'] = value
-
 
 def Browser(*args, **kwargs):
     """Emulate splinter's Browser."""
@@ -73,7 +59,6 @@ def Browser(*args, **kwargs):
         browser.visit_condition = visit_condition
         browser.visit_condition_timeout = visit_condition_timeout
         browser.visit = functools.partial(_visit, browser)
-        browser.__class__.status_code = property(_get_status_code, _set_status_code)
     browser.__splinter_browser__ = True
     return browser
 

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -48,7 +48,6 @@ def _wait_for_condition(self, condition=None, timeout=None, poll_frequency=0.5, 
     )
 
 
-
 def Browser(*args, **kwargs):
     """Emulate splinter's Browser."""
     visit_condition = kwargs.pop('visit_condition')

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://github.com/pytest-dev/pytest-splinter',
     install_requires=[
         'setuptools',
-        'splinter>=0.7.2',
+        'splinter>=0.7.3',
         'pytest',
     ],
     classifiers=[


### PR DESCRIPTION
With Splinter 0.7.3, the status_code is lazy without patching it.