### PR TITLE
Use native Selenium 2.47 socket timeout

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -234,9 +234,9 @@ def browser_pool(request, splinter_close_browser):
 
 
 @pytest.fixture(scope='session')
-def browser_patches(splinter_selenium_socket_timeout):
+def browser_patches():
     """Browser monkey patches."""
-    patch_webdriver(splinter_selenium_socket_timeout)
+    patch_webdriver()
     patch_webdriverelement()
 
 
@@ -342,6 +342,10 @@ def browser_instance_getter(
             if hasattr(browser, 'driver'):
                 browser.driver.implicitly_wait(splinter_selenium_implicit_wait)
                 browser.driver.set_speed(splinter_selenium_speed)
+
+                if splinter_webdriver == 'remote':
+                    browser.driver.command_executor.set_timeout(splinter_selenium_socket_timeout)
+
                 if splinter_window_size:
                     browser.driver.set_window_size(*splinter_window_size)
             browser.cookies.delete()

--- a/pytest_splinter/webdriver_patches.py
+++ b/pytest_splinter/webdriver_patches.py
@@ -19,20 +19,8 @@ old_request = remote_connection.RemoteConnection._request  # pragma: no cover
 RemoteWebDriver._base_execute = RemoteWebDriver.execute  # pragma: no cover
 
 
-def patch_webdriver(selenium_timeout):
+def patch_webdriver():
     """Patch selenium webdriver to add functionality/fix issues."""
-    def _request(*args, **kwargs):
-        """Override _request to set socket timeout to some appropriate value."""
-        timeout = socket.getdefaulttimeout()
-        try:
-            socket.setdefaulttimeout(selenium_timeout)
-            return old_request(*args, **kwargs)
-        finally:
-            socket.setdefaulttimeout(timeout)
-
-    # Apply the monkey patche for RemoteConnection
-    remote_connection.RemoteConnection._request = _request
-
     # Apply the monkey patch to Firefox webdriver to disable native events
     # to avoid click on wrong elements, totally unpredictable
     # more info http://code.google.com/p/selenium/issues/detail?id=633


### PR DESCRIPTION
I'm fighting with a lot of weird timeout errors and found this:
https://github.com/SeleniumHQ/selenium/commit/088820530890e254275d405082e790da09b1d239

The socket timeout monkeypatch is not needed anymore.

Just throwing the PR out here for now, don't merge this just yet, I'd like to actually try it out on our CI server and see what happens.