### PR TITLE
Remove the deprecated usage of the undocumented __multicall__ argument.

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -452,15 +452,17 @@ def browser_screenshot(
                     request.config.warn('SPL504', "Could not save screenshot: {0}".format(e))
 
 
-@pytest.mark.tryfirst
-def pytest_runtest_makereport(item, call, __multicall__):
-    """Assign the report to the item for futher usage."""
-    rep = __multicall__.execute()
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Assign the report to the item for further usage."""
+
+    outcome = yield
+    rep = outcome.get_result()
+
     if rep.outcome != 'passed':
         item.splinter_failure = rep
     else:
         item.splinter_failure = None
-    return rep
 
 
 @pytest.fixture


### PR DESCRIPTION
This commit fixes deprecation warnings occurring when pytest 2.8  is used. 