### PR TITLE
travis build fix: pinning npm selenium-standalone to 4.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - "npm install -g selenium-standalone"
+  - "npm install -g selenium-standalone@4.5.3"
   - "selenium-standalone install"
   - "selenium-standalone start &"
 env:


### PR DESCRIPTION
Builds are failing with the below. Tmp solution:

pinning npm selenium-standalone to 4.5.3 as that was the last known version where the builds functioned

```
-----
selenium-standalone installation finished
-----

/home/travis/.nvm/v0.10.36/lib/node_modules/selenium-standalone/lib/install.js:248
  fs.access(where, fs.R_OK | fs.X_OK, function(err) {
     ^
TypeError: Object #<Object> has no method 'access'
    at chmodChromeDr (/home/travis/.nvm/v0.10.36/lib/node_modules/selenium-standalone/lib/install.js:248:6)
    at /home/travis/.nvm/v0.10.36/lib/node_modules/selenium-standalone/node_modules/async/lib/async.js:699:13
    at iterate (/home/travis/.nvm/v0.10.36/lib/node_modules/selenium-standalone/node_modules/async/lib/async.js:256:13)
    at /home/travis/.nvm/v0.10.36/lib/node_modules/selenium-standalone/node_modules/async/lib/async.js:268:29
    at /home/travis/.nvm/v0.10.36/lib/node_modules/selenium-standalone/node_modules/async/lib/async.js:40:16
    at /home/travis/.nvm/v0.10.36/lib/node_modules/selenium-standalone/node_modules/async/lib/async.js:705:17
    at Object._onImmediate (/home/travis/.nvm/v0.10.36/lib/node_modules/selenium-standalone/lib/install.js:223:5)
    at processImmediate [as _immediateCallback] (timers.js:354:15)

travis_time:end:2755c7e5:start=1453894041293333893,finish=1453894042213965890,duration=920631997
[0K
[31;1mThe command "selenium-standalone install" failed and exited with 8 during .[0m

Your build has been stopped.
```