### PR TITLE
Fixed Firefox freezing when opening a missing codec extension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.7.3
+-----
+
+- fixed Firefox freezing when opening a missing codec extension (olegpidsadnyi)
+
+
 1.7.2
 -----
 

--- a/pytest_splinter/__init__.py
+++ b/pytest_splinter/__init__.py
@@ -1,2 +1,2 @@
 """pytest-splinter package."""
-__version__ = '1.7.2'
+__version__ = '1.7.3'

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -185,6 +185,7 @@ def splinter_firefox_profile_preferences():
         'toolkit.telemetry.reportingpolicy.firstRun': False,
         'datareporting.healthreport.service.firstRun': False,
         'browser.cache.disk.smart_size.first_run': False,
+        'media.gmp-gmpopenh264.enabled': False,  # Firefox hangs when the file is not found
     }
 
 


### PR DESCRIPTION
Firefox process is trying to open the gmpopenh264 extension which is missing in the current profile.
That causes random process hanging and finally a timeout between splinter and selenium.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-splinter/62)
<!-- Reviewable:end -->
