### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Install pytest-splinter
 Features
 --------
 
-The plugin provides a set of fixtures to use `splinter <http://splinter.readthedocs.org>`_
+The plugin provides a set of fixtures to use `splinter <https://splinter.readthedocs.io>`_
 for browser testing with `pytest <http://pytest.org>`_
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-splinter/65)
<!-- Reviewable:end -->
