### PR TITLE
escape screenshot paths for path separators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.7.5
+-----
+
+- escape screenshot paths for path separators (bubenkoff)
+
+
 1.7.4
 -----
 

--- a/pytest_splinter/__init__.py
+++ b/pytest_splinter/__init__.py
@@ -1,2 +1,2 @@
 """pytest-splinter package."""
-__version__ = '1.7.4'
+__version__ = '1.7.5'

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -449,8 +449,9 @@ def browser_screenshot(
 
                 classname = '.'.join(names[:-1])
                 screenshot_dir = os.path.join(splinter_screenshot_dir, classname)
-                screenshot_file_name_format = '{0}-{1}.{{format}}'.format(
-                    names[-1][:128 - len(name) - 5], name)
+                screenshot_file_name_format = '{0}.{{format}}'.format(
+                    '{0}-{1}'.format(names[-1][:128 - len(name) - 5], name).replace(os.path.sep, '-')
+                )
                 screenshot_file_name = screenshot_file_name_format.format(format='png')
                 screenshot_html_file_name = screenshot_file_name_format.format(format='html')
                 if not slaveoutput:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -176,3 +176,28 @@ def test_browser_screenshot_normal(testdir, simple_page_content):
     content = testdir.tmpdir.join('test_browser_screenshot_normal', 'test_screenshot-browser.html').read()
     assert content.replace('\n', '') == simple_page_content.replace('\n', '')
     assert testdir.tmpdir.join('test_browser_screenshot_normal', 'test_screenshot-browser.png')
+
+
+def test_browser_screenshot_escaped(testdir, simple_page_content):
+    """Test making screenshots on test failure with escaped test names.
+
+    Normal test run.
+    """
+    testdir.inline_runsource("""
+        import pytest
+
+        @pytest.fixture
+        def simple_page(httpserver, browser):
+            httpserver.serve_content(
+                '''{0}''', code=200, headers={{'Content-Type': 'text/html'}})
+            browser.visit(httpserver.url)
+
+        @pytest.mark.parametrize('param', ['escaped/param'])
+        def test_screenshot(simple_page, browser, param):
+            assert False
+    """.format(simple_page_content), "-vl", "-r w")
+
+    content = testdir.tmpdir.join(
+        'test_browser_screenshot_escaped', 'test_screenshot[escaped-param]-browser.html').read()
+    assert content.replace('\n', '') == simple_page_content.replace('\n', '')
+    assert testdir.tmpdir.join('test_browser_screenshot_escaped', 'test_screenshot[escaped-param]-browser.png')


### PR DESCRIPTION
closes #64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-splinter/68)
<!-- Reviewable:end -->
