### PR TITLE
selenium needs to be pinned to <3 for travis to be able to run integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ sudo: false
 language: python
 python: "3.4"
 addons:
-  firefox: "latest"
+  firefox: "37.0.1"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-#  - "npm install -g selenium-standalone@4.5.3"
-  - "npm install -g selenium-standalone"
+  - "npm install -g selenium-standalone@4.5.3"
   - "selenium-standalone install"
   - "selenium-standalone start &"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ sudo: false
 language: python
 python: "3.4"
 addons:
-  firefox: "37.0.1"
+  firefox: "latest"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - "npm install -g selenium-standalone@4.5.3"
+#  - "npm install -g selenium-standalone@4.5.3"
+  - "npm install -g selenium-standalone"
   - "selenium-standalone install"
   - "selenium-standalone start &"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,3 @@ branches:
 notifications:
   email:
   - bubenkoff@gmail.com
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ branches:
 notifications:
   email:
   - bubenkoff@gmail.com
+

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -4,3 +4,4 @@ pytest-localserver
 pylama
 pylama_pylint
 astroid>=1.4.5
+selenium<3


### PR DESCRIPTION
I bumped into this with my private projects, and fixed build issues by pinning selenium<3 in test requirements. Note that tests are failing, but they are not related to this fix. See the build history in by branch, and you can see that first build failed with errors like:

```
tests/test_plugin.py::test_browser Exception AttributeError: "'Service' object has no attribute 'process'" in <bound method Service.__del__ of <selenium.webdriver.firefox.service.Service object at 0x7f5452531f10>> ignored
Exception AttributeError: "'Service' object has no attribute 'process'" in <bound method Service.__del__ of <selenium.webdriver.firefox.service.Service object at 0x7f5452531250>> ignored
ERROR
```

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-splinter/76)

<!-- Reviewable:end -->
