### PR TITLE
Make it possible to override default for --splinter-wait-time.

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -120,7 +120,7 @@ def splinter_wait_time(request):
 
     :return: Seconds.
     """
-    return request.config.option.splinter_wait_time
+    return request.config.option.splinter_wait_time or 5
 
 
 @pytest.fixture(scope='session')  # pragma: no cover
@@ -608,7 +608,7 @@ def pytest_addoption(parser):  # pragma: no cover
     group.addoption(
         "--splinter-wait-time",
         help="splinter explicit wait, seconds", type="int",
-        dest='splinter_wait_time', metavar="SECONDS", default=5)
+        dest='splinter_wait_time', metavar="SECONDS", default=None)
     group.addoption(
         "--splinter-implicit-wait",
         help="pytest-splinter selenium implicit wait, seconds", type="int",


### PR DESCRIPTION
With this commit, one can override splinter_wait_time and change the
default:

```
@pytest.fixture(scope='session')
def splinter_wait_time(request):
    return request.config.option.splinter_wait_time or 8
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-splinter/87)
<!-- Reviewable:end -->
