### PR TITLE
Fixed #90 - pass the Firefox profile as `moz:firefoxOptions`

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -305,6 +305,12 @@ def get_args(driver=None,
         for key, value in firefox_profile_preferences.items():
             profile.set_preference(key, value)
         kwargs['firefox_profile'] = profile.encoded
+
+        # remote geckodriver does not support the firefox_profile desired
+        # capatibility. Instead `moz:firefoxOptions` should be used:
+        # https://github.com/mozilla/geckodriver#firefox-capabilities
+        kwargs['moz:firefoxOptions'] = {}
+        kwargs['moz:firefoxOptions']['profile'] = profile.encoded
     elif driver in ('phantomjs', 'chrome'):
         if executable:
             kwargs['executable_path'] = executable


### PR DESCRIPTION
See #90 for more information.