### PR TITLE
Broken wait_for_condition (some conditions need the switch_to api)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,6 +10,7 @@ These people have contributed to `pytest-splinter`, in alphabetical order:
 * `Andrey Makhnach <andrey.makhnach@gmail.com>`_
 * `Aymeric Augustin <https://myks.org/>`_
 * `Daniel Hahler <github@thequod.de>`_
+* `Ionel Cristian Mărieș <contact@ionelmc.ro>`_
 * `Laurence Rowe <l@lrowe.co.uk>`_
 * `Marco Buccini <markon@github.com>`_
 * `Oleg Pidsadnyi <oleg.pidsadnyi@gmail.com>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.8.2
+-----
+
+- Fixed missing `switch_to` method (some selenium `expected_conditions` are broken without 
+  it, see `#93 <https://github.com/pytest-dev/pytest-splinter/pull/93>`_)
 
 1.8.1
 -----

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -66,6 +66,7 @@ def Browser(*args, **kwargs):
     visit_condition = kwargs.pop('visit_condition')
     visit_condition_timeout = kwargs.pop('visit_condition_timeout')
     browser = splinter.Browser(*args, **kwargs)
+    browser.switch_to = browser.driver.switch_to
     browser.wait_for_condition = functools.partial(_wait_for_condition, browser)
     if hasattr(browser, 'driver'):
         browser.visit_condition = visit_condition

--- a/pytest_splinter/webdriver_patches.py
+++ b/pytest_splinter/webdriver_patches.py
@@ -62,7 +62,7 @@ def patch_webdriver():
     def get_current_window_info(self):
         atts = self.execute_script("return [ window.id, window.name, document.title, document.url ];")
         atts = [
-            att if att is not None and len(att) else 'undefined'
+            att if att is not None and att else 'undefined'
             for att in atts]
         return (self.current_window_handle, atts[0], atts[1], atts[2], atts[3])
 


### PR DESCRIPTION
Example problem:
```
  File "/app/tests/test_func/test_ui.py", line 580, in test_foobar
    browser.wait_for_condition(expected_conditions.alert_is_present())
  File "/usr/local/lib/python2.7/dist-packages/pytest_splinter/plugin.py", line 50, in _wait_for_condition
    lambda browser: condition()
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/support/wait.py", line 71, in until
    value = method(self._driver)
  File "/usr/local/lib/python2.7/dist-packages/pytest_splinter/plugin.py", line 50, in <lambda>
    lambda browser: condition()
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/support/expected_conditions.py", line 338, in __call__
    alert = driver.switch_to.alert
AttributeError: 'WebDriver' object has no attribute 'switch_to'
```