### PR TITLE
Use getfixturevalue instead of getfuncargvalue.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+NEXT
+-----
+- Use getfixturevalue instead of getfuncargvalue `#97
+  <https://github.com/pytest-dev/pytest-splinter/issues/97>`_ (pelme)
+
 1.8.5
 -----
 

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -501,9 +501,9 @@ def browser_instance_getter(
                 raise
 
     def prepare_browser(request, parent, retry_count=3):
-        splinter_webdriver = request.getfuncargvalue('splinter_webdriver')
-        splinter_session_scoped_browser = request.getfuncargvalue('splinter_session_scoped_browser')
-        splinter_close_browser = request.getfuncargvalue('splinter_close_browser')
+        splinter_webdriver = request.getfixturevalue('splinter_webdriver')
+        splinter_session_scoped_browser = request.getfixturevalue('splinter_session_scoped_browser')
+        splinter_close_browser = request.getfixturevalue('splinter_close_browser')
         browser_key = id(parent)
         browser = browser_pool.get(browser_key)
         if not splinter_session_scoped_browser:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'setuptools',
         'splinter>=0.7.3',
         'selenium>=2.47.1',
-        'pytest',
+        'pytest>=3.0.0',
     ],
     classifiers=[
         'Development Status :: 6 - Mature',


### PR DESCRIPTION
getfuncargvalue is deprecated and raises warnings.

Fixed #97.