### PR TITLE
README example code - apostrophe escapes single quotes, use double quotation marks instead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -317,7 +317,7 @@ test_your_test.py:
         button = browser.find_by_name('btnK')
         # Interact with elements
         button.click()
-        assert browser.is_text_present('splinter.cobrateam.info'), 'splinter.cobrateam.info wasn't found... We need to'
+        assert browser.is_text_present('splinter.cobrateam.info'), "splinter.cobrateam.info wasn't found... We need to"
         ' improve our SEO techniques'
 
 


### PR DESCRIPTION
The pytest-splinter example code currently has a syntax error - using an apostrophe inside a string with single quotation marks with escape the string. I've used double quotation marks there instead.

FWIW, the example code still won't run until this bug (https://github.com/pytest-dev/pytest-splinter/issues/112) has been addressed, but it appears @youtux is already working on that.