### PR TITLE
Correct webdriver executable fixture in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,8 +158,8 @@ Fixtures
     Function to get browser image (png) screenshot. By default, it calls `browser.save_sceenshot`
     with given path.
 
-* splinter_driver_executable
-    Filesystem path of the webdriver executable.
+* splinter_webdriver_executable
+    Filesystem path of the webdriver executable directory.
     This fixture gets the value from the command-line option
     `splinter-webdriver-executable` (see below).
 
@@ -219,7 +219,7 @@ Command-line options
     directory.
 
 * `--splinter-webdriver-executable`
-    Filesystem path of the webdriver executable. Used by chrome driver.
+    Filesystem path of the webdriver executable directory. Used by chrome driver.
     Defaults to the None in which case the shell PATH variable setting determines the location of the executable.
 
 


### PR DESCRIPTION
Took me a moment to discover that there's no such fixture as `splinter_driver_executable`, so here's a fix. I also clarified that it should return a *directory*, not a path to executable. Although if that is the case, perhaps we should add a `_dir` or `_directory` suffix for fixture name (and CLI option)?