### PR TITLE
browser_instance_getter gets args from request object

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -490,7 +490,6 @@ def browser_instance_getter(
             else:
                 raise
 
-
     def prepare_browser(request, parent, retry_count=3):
         splinter_webdriver = request.getfixturevalue('splinter_webdriver')
         splinter_session_scoped_browser = request.getfixturevalue('splinter_session_scoped_browser')
@@ -506,7 +505,8 @@ def browser_instance_getter(
 
         if request.scope == 'function':
             def _take_screenshot_on_failure():
-                if request.getfixturevalue('splinter_make_screenshot_on_failure') and getattr(request.node, 'splinter_failure', True):
+                screenshot_on_failure = request.getfixturevalue('splinter_make_screenshot_on_failure')
+                if screenshot_on_failure and getattr(request.node, 'splinter_failure', True):
                     _take_screenshot(
                         request=request,
                         fixture_name=parent.__name__,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,7 +6,6 @@ import socket
 import pytest
 
 from splinter.driver import DriverAPI
-from pytest_splinter.plugin import get_args
 
 
 @pytest.fixture
@@ -166,10 +165,33 @@ def test_current_window_is_main(browser, splinter_webdriver):
     assert browser.driver.current_window_is_main()
 
 
-def test_executable():
+def test_executable(testdir, request):
     """Test argument construction for webdrivers."""
-    arg1 = get_args(driver='chrome', executable='/tmp')
-    assert arg1['executable_path'] == '/tmp'
+    testdir.makeconftest("""
+        import pytest
+
+
+        @pytest.fixture(scope='session')
+        def splinter_webdriver(request):
+            return 'chrome'
+
+
+        @pytest.fixture(scope='session')
+        def splinter_webdriver_executable(request):
+            return '/tmp'
+        """)
+
+    testdir.makepyfile("""
+        from pytest_splinter.plugin import get_args
+
+
+        def test_executable(request):
+            arg1 = get_args(request)
+            assert arg1['executable_path'] == '/tmp'
+    """)
+
+    result = testdir.runpytest('-v')
+    assert result.ret == 0
 
 
 def assert_valid_html_screenshot_content(content):


### PR DESCRIPTION
This PR changes the functions nested inside browser_instance_getter to receive the request object and pull fixture values directly, instead of passing the fixture values in from browser_instance_getter.

The reason for this is because passing the fixture values from browser_instance_getter forces them to always be session scoped. Since browser_instance_getter is session scoped, the fixtures are only accessed once. Accessing the request object allows the fixtures to be function scoped.

The main reason for this change is the necessity to have `splinter_driver_kwargs` set on a per-test basis.

ie:

The following now works:
```
@pytest.fixture(scope="function")
def splinter_driver_kwargs(request):
    return {
        'name': request.node.name,
    },
```

