### PR TITLE
Simplify --splinter-headless

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,3 +22,4 @@ These people have contributed to `pytest-splinter`, in alphabetical order:
 * `Peter Lauri <peterlauri@gmail.com>`_
 * `Suresh V <sureshvv@github.com>`_
 * `Tomáš Ehrlich <tomas.ehrlich@gmail.com>`_
+* `Tony Narlock <tony@git-pull.com>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+- Passing `--splinter-headless` without arguments defaults to 'true'
+  `#123 <https://github.com/pytest-dev/pytest-splinter/pull/123>`_ (tony)
+
 3.1.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -222,7 +222,8 @@ Command-line options
     Defaults to the None in which case the shell PATH variable setting determines the location of the executable.
 
 * `--splinter-headless`
-    Run Chrome in headless mode. Defaults to false. http://splinter.readthedocs.io/en/latest/drivers/chrome.html#using-headless-option-for-chrome
+    Override `splinter_headless` fixture. Choices are 'true' or 'false', default: 'true'.
+    http://splinter.readthedocs.io/en/latest/drivers/chrome.html#using-headless-option-for-chrome
 
 Browser fixture
 ---------------

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -774,11 +774,8 @@ def pytest_addoption(parser):  # pragma: no cover
     )
     group.addoption(
         "--splinter-headless",
-        help="Run the browser in headless mode. Defaults to false. Only applies to Chrome.",
-        action="store",
+        help="Run the browser in headless mode. Only applies to Chrome.",
+        action="store_true",
         dest="splinter_headless",
-        metavar="false|true",
-        type=str,
-        choices=["false", "true"],
         default="false",
     )


### PR DESCRIPTION
It feels a bit strange doing true/false for a headless option.
It could be my own aesthetic / tastes.

`argparse` has `'store_true'` for cases like this (see [docs](https://docs.python.org/3/library/argparse.html#action)):

> 'store_true' and 'store_false' - These are special cases of 'store_const' used for storing the values True and False respectively. In addition, they create default values of `False` and `True` respectively..

So `--headless` sets it to `True`.

I can't think of a case where a user would want to accept False considering the default behavior is that, but if they did, they can always add their own option via `pytest_addoption`)

Not entering --splinter-headless infers False (this is backed by default values in pytest-splinter and probably user intuition). Entering --headless implies the user wants to run in headless mode.