### PR TITLE
Use splinter screenshot methods

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -393,14 +393,14 @@ def _take_screenshot(
     LOGGER.info('Saving screenshot to {}'.format(screenshot_dir))
 
     try:
-        html_snapshot_path = splinter_screenshot_getter_html(browser_instance, screenshot_path)
+        screenshot_html_path = splinter_screenshot_getter_html(browser_instance, screenshot_path)
         screenshot_png_path = splinter_screenshot_getter_png(browser_instance, screenshot_path)
 
         if request.node.splinter_failure.longrepr:
             reprtraceback = request.node.splinter_failure.longrepr.reprtraceback
-            reprtraceback.extraline = _screenshot_extraline(screenshot_png_path, html_snapshot_path)
+            reprtraceback.extraline = _screenshot_extraline(screenshot_png_path, screenshot_html_path)
         if slaveoutput is not None:
-            with codecs.open(html_snapshot_path, encoding=splinter_screenshot_encoding) as html_fd:
+            with codecs.open(screenshot_html_path, encoding=splinter_screenshot_encoding) as html_fd:
                 with open(screenshot_png_path, 'rb') as fd:
                     slaveoutput.setdefault('screenshots', []).append({
                         'class_name': classname,
@@ -410,7 +410,7 @@ def _take_screenshot(
                                 'content': fd.read(),
                             },
                             {
-                                'file_name': html_snapshot_path,
+                                'file_name': screenshot_html_path,
                                 'content': html_fd.read(),
                                 'encoding': splinter_screenshot_encoding,
                             }]

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -340,7 +340,7 @@ def get_args(driver=None,
 def splinter_screenshot_getter_png():
     """Screenshot getter function: png."""
     def getter(browser, path):
-        browser.driver.save_screenshot(path)
+        return browser.screenshot(path)
     return getter
 
 
@@ -348,8 +348,9 @@ def splinter_screenshot_getter_png():
 def splinter_screenshot_getter_html(splinter_screenshot_encoding):
     """Screenshot getter function: html."""
     def getter(browser, path):
-        with codecs.open(path, 'w', encoding=splinter_screenshot_encoding) as fd:
-            fd.write(browser.html)
+        return browser.html_snapshot(
+            path, encoding=splinter_screenshot_encoding,
+        )
     return getter
 
 
@@ -379,37 +380,37 @@ def _take_screenshot(
 
     classname = '.'.join(names[:-1])
     screenshot_dir = os.path.join(splinter_screenshot_dir, classname)
-    screenshot_file_name_format = '{0}.{{format}}'.format(
-        '{}-{}'.format(names[-1][:128 - len(fixture_name) - 5], fixture_name).replace(os.path.sep, '-')
-    )
-    screenshot_file_name = screenshot_file_name_format.format(format='png')
-    screenshot_html_file_name = screenshot_file_name_format.format(format='html')
+
     if not slaveoutput:
         if not os.path.exists(screenshot_dir):
             os.makedirs(screenshot_dir)
     else:
         screenshot_dir = session_tmpdir.ensure('screenshots', dir=True).strpath
-    screenshot_png_path = os.path.join(screenshot_dir, screenshot_file_name)
-    screenshot_html_path = os.path.join(screenshot_dir, screenshot_html_file_name)
-    LOGGER.info('Saving screenshot to %s', screenshot_dir)
+
+    screenshot_base_file_name = '{}-{}-'.format(names[-1][:128 - len(fixture_name) - 5], fixture_name).replace(os.path.sep, '-')
+    screenshot_path = os.path.join(screenshot_dir, screenshot_base_file_name)
+
+    LOGGER.info('Saving screenshot to {}'.format(screenshot_dir))
+
     try:
-        splinter_screenshot_getter_html(browser_instance, screenshot_html_path)
-        splinter_screenshot_getter_png(browser_instance, screenshot_png_path)
+        html_snapshot_path = splinter_screenshot_getter_html(browser_instance, screenshot_path)
+        screenshot_png_path = splinter_screenshot_getter_png(browser_instance, screenshot_path)
+
         if request.node.splinter_failure.longrepr:
             reprtraceback = request.node.splinter_failure.longrepr.reprtraceback
-            reprtraceback.extraline = _screenshot_extraline(screenshot_png_path, screenshot_html_path)
+            reprtraceback.extraline = _screenshot_extraline(screenshot_png_path, html_snapshot_path)
         if slaveoutput is not None:
-            with codecs.open(screenshot_html_path, encoding=splinter_screenshot_encoding) as html_fd:
+            with codecs.open(html_snapshot_path, encoding=splinter_screenshot_encoding) as html_fd:
                 with open(screenshot_png_path, 'rb') as fd:
                     slaveoutput.setdefault('screenshots', []).append({
                         'class_name': classname,
                         'files': [
                             {
-                                'file_name': screenshot_file_name,
+                                'file_name': screenshot_png_path,
                                 'content': fd.read(),
                             },
                             {
-                                'file_name': screenshot_html_file_name,
+                                'file_name': html_snapshot_path,
                                 'content': html_fd.read(),
                                 'encoding': splinter_screenshot_encoding,
                             }]

--- a/tests/mocked_browser/conftest.py
+++ b/tests/mocked_browser/conftest.py
@@ -25,11 +25,13 @@ def mocked_browser(browser_pool, request):
         mocked_browser.driver_name = driver_name
         mocked_browser.html = u'<html></html>'
 
-        def save_screenshot(path):
-            with open(path, 'w'):
+        def screenshot(path):
+            filename = '{}.png'.format(path)
+            with open(filename, 'w'):
                 pass
+            return filename
 
-        mocked_browser.driver.save_screenshot = save_screenshot
+        mocked_browser.screenshot = screenshot
         return mocked_browser
 
     patcher = mock.patch('pytest_splinter.plugin.splinter.Browser', mocked_browser)

--- a/tests/mocked_browser/test_screenshot.py
+++ b/tests/mocked_browser/test_screenshot.py
@@ -1,4 +1,6 @@
 """Browser screenshot tests."""
+import os
+
 import pytest
 
 import mock
@@ -14,13 +16,13 @@ def test_browser_screenshot_normal(mocked_browser, testdir):
             assert False
     """, "-vls", "--splinter-session-scoped-browser=false")
 
-    assert testdir.tmpdir.join('test_browser_screenshot_normal', 'test_screenshot-browser.png').isfile()
+    assert testdir.tmpdir.join('test_browser_screenshot_normal', 'test_screenshot-browser-.png').isfile()
 
 
 @mock.patch('pytest_splinter.plugin.splinter.Browser')
 def test_browser_screenshot_error(mocked_browser, testdir):
     """Test warning with error during taking screenshots on test failure."""
-    mocked_browser.return_value.driver.save_screenshot.side_effect = Exception('Failed')
+    mocked_browser.return_value.screenshot.side_effect = Exception('Failed')
     mocked_browser.return_value.driver_name = 'firefox'
     mocked_browser.return_value.html = u'<html>'
 
@@ -43,5 +45,9 @@ def test_browser_screenshot_xdist(testdir):
             assert False
     """, "-vl", "-n1")
 
-    assert testdir.tmpdir.join('test_browser_screenshot_xdist', 'test_screenshot-browser.png').isfile()
-    assert testdir.tmpdir.join('test_browser_screenshot_xdist', 'test_screenshot-browser.html').isfile()
+    dir_content = os.listdir('test_browser_screenshot_xdist')
+    matches = [i for i in dir_content if i.startswith('test_screenshot-browser')]
+    assert 2 == len(matches)
+
+    assert testdir.tmpdir.join('test_browser_screenshot_xdist', matches[0]).isfile()
+    assert testdir.tmpdir.join('test_browser_screenshot_xdist', matches[1]).isfile()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,5 @@
 """Tests for pytest-splinter plugin."""
+import os
 import os.path
 import time
 import socket
@@ -199,8 +200,11 @@ def test_screenshot(simple_page, browser):
     assert False
     """.format(simple_page_content), "-vl", "-r w")
 
-    assert testdir.tmpdir.join('test_browser_screenshot_normal', 'test_screenshot-browser.png')
-    content = testdir.tmpdir.join('test_browser_screenshot_normal', 'test_screenshot-browser.html').read()
+    dir_content = os.listdir('test_browser_screenshot_normal')
+    matches = [i for i in dir_content if i.startswith('test_screenshot-browser') and i.endswith('.html')]
+    assert 1 == len(matches)
+
+    content = testdir.tmpdir.join('test_browser_screenshot_normal', matches[0]).read()
     assert_valid_html_screenshot_content(content)
 
 
@@ -223,10 +227,11 @@ def test_screenshot(simple_page, browser):
     assert False
     """.format(simple_page_content), "-vl", "-r w", '--splinter-session-scoped-browser=false')
 
-    content = testdir.tmpdir.join(
-        'test_browser_screenshot_function_scoped_browser',
-        'test_screenshot-browser.html'
-    ).read()
+    dir_content = os.listdir('test_browser_screenshot_function_scoped_browser')
+    matches = [i for i in dir_content if i.startswith('test_screenshot-browser') and i.endswith('.html')]
+    assert 1 == len(matches)
+
+    content = testdir.tmpdir.join('test_browser_screenshot_function_scoped_browser', matches[0]).read()
 
     assert_valid_html_screenshot_content(content)
     assert testdir.tmpdir.join('test_browser_screenshot_normal', 'test_screenshot-browser.png')
@@ -252,8 +257,12 @@ def test_screenshot(simple_page, browser, param):
     assert False
     """.format(simple_page_content), "-vl", "-r w")
 
-    content = testdir.tmpdir.join(
-        'test_browser_screenshot_escaped', 'test_screenshot[escaped-param]-browser.html').read()
+    dir_content = os.listdir('test_browser_screenshot_escaped')
+    matches = [i for i in dir_content if i.startswith('test_screenshot[escaped-param]-browser') and i.endswith('.html')]
+    assert 1 == len(matches)
+
+    content = testdir.tmpdir.join('test_browser_screenshot_escaped', matches[0]).read()
+
     assert_valid_html_screenshot_content(content)
     assert testdir.tmpdir.join('test_browser_screenshot_escaped', 'test_screenshot[escaped-param]-browser.png')
 


### PR DESCRIPTION
The latest version of splinter includes an html_snapshot method. We can use that and splinter's screenshot method to simplify the _take_screenshot method slightly.