### PR TITLE
Enable window resizing for Chrome Browser

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -553,9 +553,7 @@ def browser_instance_getter(
                 browser.driver.set_speed(splinter_selenium_speed)
                 browser.driver.command_executor.set_timeout(splinter_selenium_socket_timeout)
                 browser.driver.command_executor._conn.timeout = splinter_selenium_socket_timeout
-                if splinter_window_size and splinter_webdriver != "chrome":
-                    # Chrome cannot resize the window
-                    # https://github.com/SeleniumHQ/selenium/issues/3508
+                if splinter_window_size:
                     browser.driver.set_window_size(*splinter_window_size)
             try:
                 browser.cookies.delete()


### PR DESCRIPTION
The https://github.com/SeleniumHQ/selenium/issues/3508 issue has been closed and I've verified that window resizing does in fact work on Chrome now with the latest version of Selenium.