### PR TITLE
Remove readme section "Several browsers for your test"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,25 +237,6 @@ As mentioned above, browser is a fixture made by creating splinter's Browser obj
     so there you can do whatever you want, and not only execute javascript via browser.evaluate_script.
 
 
-Several browsers for your test
-------------------------------
-
-You can have several browsers in one test.
-
-.. code-block:: python
-
-    import pytest
-
-    @pytest.fixture
-    def admin_browser(browser_instance_getter):
-        return browser_instance_getter(admin_browser)
-
-    def test_with_several_browsers(browser, admin_browser):
-        browser.visit('http://example.com')
-        admin_browser.visit('about:blank')
-        assert browser.url == 'http://example.com'
-
-
 Automatic screenshots on test failure
 -------------------------------------
 


### PR DESCRIPTION
`browser_instance_getter()` is documented in 2 places in the README:

1. On https://github.com/pytest-dev/pytest-splinter/blob/master/README.rst#several-browsers-for-your-test However, following that example gives me: `TypeError: prepare_browser() missing 1 required positional argument: 'parent'`
2. Under https://github.com/pytest-dev/pytest-splinter/blob/master/README.rst#fixtures That code works, and the example also explains why one would want to do this. 

I think the chapter https://github.com/pytest-dev/pytest-splinter/blob/master/README.rst#several-browsers-for-your-test can be deleted.