### PR TITLE
Fix pytest-splinter when using splinter >= 0.12.0

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -311,18 +311,19 @@ def get_args(driver=None,
         kwargs['profile'] = firefox_prof_dir
     elif driver == 'remote':
         if remote_url:
-            kwargs['url'] = remote_url
+            kwargs['command_executor'] = remote_url
         kwargs['keep_alive'] = True
         profile = FirefoxProfile(firefox_prof_dir)
         for key, value in firefox_profile_preferences.items():
             profile.set_preference(key, value)
-        kwargs['firefox_profile'] = profile.encoded
+        kwargs['desired_capabilities'] = driver_kwargs.get('desired_capabilities', {})
+        kwargs['desired_capabilities']['firefox_profile'] = profile.encoded
 
         # remote geckodriver does not support the firefox_profile desired
         # capatibility. Instead `moz:firefoxOptions` should be used:
         # https://github.com/mozilla/geckodriver#firefox-capabilities
-        kwargs['moz:firefoxOptions'] = driver_kwargs.get('moz:firefoxOptions', {})
-        kwargs['moz:firefoxOptions']['profile'] = profile.encoded
+        kwargs['desired_capabilities']['moz:firefoxOptions'] = driver_kwargs.get('moz:firefoxOptions', {})
+        kwargs['desired_capabilities']['moz:firefoxOptions']['profile'] = profile.encoded
     elif driver in ('chrome',):
         if executable:
             kwargs['executable_path'] = executable

--- a/pytest_splinter/splinter_patches.py
+++ b/pytest_splinter/splinter_patches.py
@@ -2,7 +2,6 @@
 from functools import partial
 
 from splinter.driver.webdriver import firefox
-from splinter.driver.webdriver import remote
 
 from selenium.webdriver.common.action_chains import ActionChains  # pragma: no cover
 
@@ -19,6 +18,3 @@ def patch_webdriverelement():  # pragma: no cover
 
     # Apply the monkey patch for Firefox WebDriverElement
     firefox.WebDriverElement.mouse_over = mouse_over
-
-    # Enable keep_alive for remove driver
-    remote.Remote = partial(remote.Remote, keep_alive=True)

--- a/pytest_splinter/webdriver_patches.py
+++ b/pytest_splinter/webdriver_patches.py
@@ -25,14 +25,6 @@ old_request = remote_connection.RemoteConnection._request  # pragma: no cover
 # save the original execute
 RemoteWebDriver._base_execute = RemoteWebDriver.execute  # pragma: no cover
 
-old_init = RemoteWebDriver.__init__  # pragma: no cover
-
-
-def __init__(self, *args, **kwargs):
-    """Set keep_alive to True."""
-    kwargs['keep_alive'] = True
-    return old_init(self, *args, **kwargs)
-
 
 def patch_webdriver():
     """Patch selenium webdriver to add functionality/fix issues."""
@@ -85,4 +77,3 @@ def patch_webdriver():
     RemoteWebDriver.execute = execute
     RemoteWebDriver.get_current_window_info = get_current_window_info
     RemoteWebDriver.current_window_is_main = current_window_is_main
-    RemoteWebDriver.__init__ = __init__

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://github.com/pytest-dev/pytest-splinter',
     install_requires=[
         'setuptools',
-        'splinter>=0.9.0',
+        'splinter>=0.12.0',
         'selenium',
         'pytest>=3.0.0',
         'urllib3',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -256,3 +256,11 @@ def test_screenshot(simple_page, browser, param):
         'test_browser_screenshot_escaped', 'test_screenshot[escaped-param]-browser.html').read()
     assert_valid_html_screenshot_content(content)
     assert testdir.tmpdir.join('test_browser_screenshot_escaped', 'test_screenshot[escaped-param]-browser.png')
+
+
+def test_keep_alive(simple_page, browser, splinter_webdriver):
+    """Test that Remote WebDriver keep_alive is True."""
+    if splinter_webdriver != "remote":
+        pytest.skip('Only Remote WebDriver uses keep_alive argument')
+
+    assert browser.driver.keep_alive


### PR DESCRIPTION
Specifically, the way arguments and desired_capabilities are sent to Remote WebDriver has changed.