### PR TITLE
Bump minimum splinter version to 0.13.0.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+3.0.0
+-----
+
+- Bump minimum splinter version to 0.13.0 (jsfehler)
+- Remove unnecessary webdriver patch for retries, this behaviour is now part of splinter. (jsfehler)
+
 2.1.0
 -----
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,16 @@
 Changelog
 =========
 
+
+3.1.0
+-----
+
+- Remove unnecessary webdriver patch for retries, this behaviour is now part of splinter. (jsfehler)
+
 3.0.0
 -----
 
 - Bump minimum splinter version to 0.13.0 (jsfehler)
-- Remove unnecessary webdriver patch for retries, this behaviour is now part of splinter. (jsfehler)
 
 2.1.0
 -----

--- a/pytest_splinter/webdriver_patches.py
+++ b/pytest_splinter/webdriver_patches.py
@@ -6,51 +6,19 @@ http://code.google.com/p/selenium/issues/detail?id=5176.
 """
 
 import time  # pragma: no cover
-import socket  # pragma: no cover
 
-try:
-    from httplib import HTTPException
-except ImportError:
-    from http.client import HTTPException
-
-import urllib3
-from urllib3.exceptions import MaxRetryError
-
-from selenium.webdriver.remote import remote_connection  # pragma: no cover
 from selenium.webdriver.firefox import webdriver  # pragma: no cover
 from selenium.webdriver.remote.webdriver import (
     WebDriver as RemoteWebDriver,
 )  # pragma: no cover
 
 
-# Get the original _request and store for future use in the monkey patched version as 'super'
-old_request = remote_connection.RemoteConnection._request  # pragma: no cover
 # save the original execute
 RemoteWebDriver._base_execute = RemoteWebDriver.execute  # pragma: no cover
 
 
 def patch_webdriver():
     """Patch selenium webdriver to add functionality/fix issues."""
-
-    def _request(self, *args, **kwargs):
-        """Override _request to set socket timeout to some appropriate value."""
-        exception = HTTPException("Unable to get response")
-        for _ in range(3):
-            try:
-                return old_request(self, *args, **kwargs)
-            except (
-                socket.error,
-                HTTPException,
-                IOError,
-                OSError,
-                MaxRetryError,
-            ) as exc:
-                exception = exc
-                self._conn = urllib3.PoolManager(timeout=self._timeout)
-        raise exception
-
-    # Apply the monkey patch for RemoteConnection
-    remote_connection.RemoteConnection._request = _request
 
     # Apply the monkey patch to Firefox webdriver to disable native events
     # to avoid click on wrong elements, totally unpredictable

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://github.com/pytest-dev/pytest-splinter',
     install_requires=[
         'setuptools',
-        'splinter>=0.12.0',
+        'splinter>=0.13.0',
         'selenium',
         'pytest>=3.0.0',
         'urllib3',


### PR DESCRIPTION
Splinter 0.13.0 overrides Selenium's request in the same way, making this part of pytest-splinter unnecessary. See: https://github.com/cobrateam/splinter/blob/master/splinter/driver/webdriver/remote_connection.py
