### PR TITLE
Fix --splinter-headless, as it could as well be of type bool, not str.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.3.1
+-----
+
+- Fix handling of command-line option ``splinter_headless`` (mpasternak)
+
 3.3.0
 -----
 

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -237,7 +237,7 @@ def splinter_screenshot_dir(request):
 @pytest.fixture(scope="session")
 def splinter_headless(request):
     """Flag to start the browser in headless mode."""
-    return request.config.option.splinter_headless == True
+    return request.config.option.splinter_headless
 
 
 @pytest.fixture(scope="session")  # pragma: no cover
@@ -781,5 +781,4 @@ def pytest_addoption(parser):  # pragma: no cover
         help="Run the browser in headless mode.",
         action="store_true",
         dest="splinter_headless",
-        default="false",
     )

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -237,10 +237,7 @@ def splinter_screenshot_dir(request):
 @pytest.fixture(scope="session")
 def splinter_headless(request):
     """Flag to start the browser in headless mode."""
-    return (
-        request.config.option.splinter_headless == "true"
-        or request.config.option.splinter_headless == True
-    )
+    return request.config.option.splinter_headless == True
 
 
 @pytest.fixture(scope="session")  # pragma: no cover

--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -237,7 +237,10 @@ def splinter_screenshot_dir(request):
 @pytest.fixture(scope="session")
 def splinter_headless(request):
     """Flag to start the browser in headless mode."""
-    return request.config.option.splinter_headless == "true"
+    return (
+        request.config.option.splinter_headless == "true"
+        or request.config.option.splinter_headless == True
+    )
 
 
 @pytest.fixture(scope="session")  # pragma: no cover


### PR DESCRIPTION
Thank you for helping with getting my previous suggestions included in the main branch, also thank you for releasing the package on PyPI. 

I have tested 3.3.0 and it won't work as documented, unless you create this small patch. 

Also please note I have not tested other cases when a ``splinter_*`` variable is compared to a string ``"true"``, but they could be as well dysfunctional. 
