### PR TITLE
Fix auto screenshots for session browser with latest pytest

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -467,15 +467,8 @@ def _browser_screenshot_session(
     if not splinter_session_scoped_browser:
         return
 
-    fixture_values = (
-        # pytest 3
-        getattr(request, "_fixture_values", {})
-        or
-        # pytest 2
-        getattr(request, "_funcargs", {})
-    )
-
-    for name, value in fixture_values.items():
+    for name in request.fixturenames:
+        value = request.getfixturevalue(name)
         should_take_screenshot = (
             hasattr(value, "__splinter_browser__")
             and splinter_make_screenshot_on_failure


### PR DESCRIPTION
_fixture_values and _funcargs properties, the internal API for FixtureRequest
object, are no longer available in latest versions of pytest. It appears
fixturenames property and getfixturevalue() method can be used for the purpose
of retrieving all session_browser fixture instances. According to changelog,
both are available on pytest 3.0.0 and up.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>