### PR TITLE
build(setup.py): Add `project_urls` for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,12 @@ setup(
     version=pytest_splinter.__version__,
     include_package_data=True,
     url='https://github.com/pytest-dev/pytest-splinter',
+    project_urls={
+        "Bug Tracker": "https://github.com/pytest-dev/pytest-splinter/issues",
+        "Changes": "https://github.com/pytest-dev/pytest-splinter/blob/master/CHANGES.rst",
+        "Documentation": "https://github.com/pytest-dev/pytest-splinter/blob/master/README.rst",
+        "Source Code": "https://github.com/pytest-dev/pytest-splinter",
+    },
     install_requires=[
         'setuptools',
         'splinter>=0.13.0',


### PR DESCRIPTION
Add [`project_urls`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls) to _setup.py_

For [pytest-splinter's PyPI page](https://pypi.org/project/pytest-splinter/) to get easy links to project pages:
![image](https://user-images.githubusercontent.com/26336/179763471-5f49113b-c654-4e60-bc0a-db2e7d04d04b.png)