### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/pytest_splinter/plugin.py
+++ b/pytest_splinter/plugin.py
@@ -449,7 +449,7 @@ def _take_screenshot(
         warnings.warn(pytest.PytestWarning("Could not save screenshot: {}".format(e)))
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def _browser_screenshot_session(
     request,
     session_tmpdir,
@@ -607,12 +607,12 @@ def browser_instance_getter(
                     # https://github.com/SeleniumHQ/selenium/issues/3508
                     browser.driver.set_window_size(*splinter_window_size)
             try:
-                browser.cookies.delete()
+                browser.cookies.delete_all()
             except (IOError, HTTPException, WebDriverException):
                 LOGGER.warning("Error cleaning browser cookies", exc_info=True)
             for url in splinter_clean_cookies_urls:
                 browser.visit(url)
-                browser.cookies.delete()
+                browser.cookies.delete_all()
             if hasattr(browser, "driver"):
                 browser.visit_condition = splinter_browser_load_condition
                 browser.visit_condition_timeout = splinter_browser_load_timeout

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     },
     install_requires=[
         'setuptools',
-        'splinter>=0.13.0',
+        'splinter>=0.15.0',
         'selenium',
         'pytest>=3.0.0',
         'urllib3',

--- a/tests/mocked_browser/conftest.py
+++ b/tests/mocked_browser/conftest.py
@@ -10,7 +10,7 @@ def splinter_session_scoped_browser():
     return False
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def mocked_browser(browser_pool, request):
     """Mock splinter browser."""
     # to avoid re-using of cached browser from other tests


### PR DESCRIPTION
- fix cookies.delete() deprecated in splinter, delete_all added in spliter 0.15
- remove pytest.yield_fixture as it deprecated since pytest 3.0 