### PR TITLE
Create .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,8 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Paylogic got an email from readthedocs that they need a config file soon. This is the most minimal file as suggested by https://blog.readthedocs.com/migrate-configuration-v2/. 

We're also fine transferring ownership of the readthedocs to https://github.com/pytest-dev.